### PR TITLE
Add "Copy Previous Workout" Feature to Calendar Page

### DIFF
--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -9,8 +9,6 @@ export const saveWorkoutEntry = async (entry: Workout) => {
 
         // Save the workout entry to Firestore
         await setDoc(entryRef, entry);
-
-        console.log("Workout entry saved successfully in Firestore");
     } catch (error) {
         console.error("Failed to save workout data:", error);
         throw new Error("Failed to save workout data: " + error);
@@ -44,8 +42,6 @@ export const deleteWorkoutEntry = async (workoutId: string): Promise<void> => {
      
       const workoutRef = doc(db, `workouts/${workoutId}`);
       await deleteDoc(workoutRef);
-
-      console.log(`Workout entry with ID ${workoutId} deleted successfully`);
   } catch (error) {
       console.error("Failed to delete workout:", error);
       throw new Error("Failed to delete workout: " + error);
@@ -61,8 +57,6 @@ export const editWorkoutEntry = async (entry: Workout): Promise<void> => {
 
         // Update the workout entry in Firestore, merging with existing data
         await setDoc(entryRef, entry, { merge: true });
-
-        console.log("Workout entry updated successfully in Firestore");
     } catch (error) {
         console.error("Failed to update workout data:", error);
         throw new Error("Failed to update workout data: " + error);

--- a/src/components/CopyWorkoutDialog.tsx
+++ b/src/components/CopyWorkoutDialog.tsx
@@ -1,0 +1,75 @@
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Workout } from "@/interfaces/workout";
+import { useState } from "react";
+import { format } from "date-fns";
+
+interface CopyWorkoutDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workouts: Workout[];
+  onSelectWorkout: (workout: Workout) => void;
+}
+
+const CopyWorkoutDialog = ({
+  open,
+  onOpenChange,
+  workouts,
+  onSelectWorkout,
+}: CopyWorkoutDialogProps) => {
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
+
+  const handleDateSelect = (date: Date | undefined) => {
+    setSelectedDate(date);
+  };
+
+  const handleConfirm = () => {
+    if (selectedDate) {
+      const workoutsForDate = workouts.filter(
+        (workout) =>
+          format(new Date(workout.date), "yyyy-MM-dd") ===
+          format(selectedDate, "yyyy-MM-dd")
+      );
+      if (workoutsForDate.length > 0) {
+        onSelectWorkout(workoutsForDate[0]); // Copy the first workout for the selected date
+        onOpenChange(false);
+      }
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Copy a Previous Workout</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-4">
+          <Calendar
+            mode="single"
+            selected={selectedDate}
+            onSelect={handleDateSelect}
+            className="rounded-md"
+            modifiers={{
+              workout: workouts.map((workout) => new Date(workout.date)),
+            }}
+            modifiersClassNames={{
+              workout:
+                "bg-primary/10 text-primary font-medium border border-primary/20",
+            }}
+          />
+          <Button onClick={handleConfirm} disabled={!selectedDate}>
+            Confirm
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CopyWorkoutDialog;

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -1,21 +1,22 @@
-import { useState, useEffect } from 'react';
-import { format } from 'date-fns';
-import { useNavigate } from 'react-router-dom';
-import { Calendar } from '@/components/ui/calendar';
-import { Card } from '@/components/ui/card';
+import { useState, useEffect } from "react";
+import { format } from "date-fns";
+import { useNavigate } from "react-router-dom";
+import { Calendar } from "@/components/ui/calendar";
+import { Card } from "@/components/ui/card";
 import { Header } from "@/components/Header";
-import { Footer } from '@/components/Footer';
-import WorkoutForm from '@/components/WorkoutForm';
-import WorkoutList from '@/components/WorkoutList';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Button } from '@/components/ui/button';
-import { PlusCircle, Search, FolderPlus } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
-import { Workout } from '@/interfaces/workout';
-import WorkoutSelectionDialog from '@/components/WorkoutSelectionDialog';
-import { useAuth } from '@/context/AuthContext';
-import axios from 'axios';
-import { saveWorkout,deleteWorkout } from '@/api/workout';
+import { Footer } from "@/components/Footer";
+import WorkoutForm from "@/components/WorkoutForm";
+import WorkoutList from "@/components/WorkoutList";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { PlusCircle, Search, FolderPlus } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { Workout } from "@/interfaces/workout";
+import WorkoutSelectionDialog from "@/components/WorkoutSelectionDialog";
+import CopyWorkoutDialog from "@/components/CopyWorkoutDialog";
+import { useAuth } from "@/context/AuthContext";
+import axios from "axios";
+import { saveWorkout, deleteWorkout } from "@/api/workout";
 
 const Workouts = () => {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
@@ -23,6 +24,7 @@ const Workouts = () => {
   const [isAddingWorkout, setIsAddingWorkout] = useState(false);
   const [editingWorkout, setEditingWorkout] = useState<Workout | null>(null);
   const [workoutDialogOpen, setWorkoutDialogOpen] = useState(false);
+  const [copyWorkoutDialogOpen, setCopyWorkoutDialogOpen] = useState(false);
   const { toast } = useToast();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -31,18 +33,20 @@ const Workouts = () => {
     const fetchWorkouts = async () => {
       if (user?.uid) {
         try {
-          const response = await axios.get(`http://localhost:3000/api/workout/get/${user.uid}`);
+          const response = await axios.get(
+            `http://localhost:3000/api/workout/get/${user.uid}`
+          );
           const fetchedWorkouts = response.data.map((workout: Workout) => ({
             ...workout,
             date: new Date(workout.date), // Ensure the date is a Date object
           }));
           setWorkouts(fetchedWorkouts);
         } catch (error) {
-          console.error('Error fetching workouts:', error);
+          console.error("Error fetching workouts:", error);
           toast({
-            title: 'Error',
-            description: 'Failed to fetch workouts',
-            variant: 'destructive',
+            title: "Error",
+            description: "Failed to fetch workouts",
+            variant: "destructive",
           });
         }
       }
@@ -52,14 +56,16 @@ const Workouts = () => {
   }, [user]);
 
   useEffect(() => {
-    localStorage.setItem('workouts', JSON.stringify(workouts));
+    localStorage.setItem("workouts", JSON.stringify(workouts));
   }, [workouts]);
 
   const selectedDateWorkouts = workouts.filter(
-    workout => format(new Date(workout.date), 'yyyy-MM-dd') === format(selectedDate, 'yyyy-MM-dd')
+    (workout) =>
+      format(new Date(workout.date), "yyyy-MM-dd") ===
+      format(selectedDate, "yyyy-MM-dd")
   );
 
-  const workoutDates = workouts.map(workout => new Date(workout.date));
+  const workoutDates = workouts.map((workout) => new Date(workout.date));
 
   const handleDateSelect = (date: Date | undefined) => {
     if (date) {
@@ -74,35 +80,35 @@ const Workouts = () => {
       ...selectedWorkout,
       id: crypto.randomUUID(),
       date: selectedDate,
-      userId: user.uid
+      userId: user.uid,
     };
 
-    const payload={
-      workout:newWorkout
-    }
+    const payload = {
+      workout: newWorkout,
+    };
 
-     //Save to database
-     saveWorkout(payload)
-    
+    //Save to database
+    saveWorkout(payload);
+
     setWorkouts([...workouts, newWorkout]);
-    
+
     toast({
       title: "Workout Added",
       description: `${selectedWorkout.name} has been added to your calendar.`,
     });
-    
+
     setWorkoutDialogOpen(false);
   };
 
   const handleCreateNewWorkout = () => {
-    navigate('/exercise-search');
+    navigate("/exercise-search");
   };
 
-  const handleAddWorkout = (workout: Omit<Workout, 'id'>) => {
+  const handleAddWorkout = (workout: Omit<Workout, "id">) => {
     const newWorkout = {
       ...workout,
       id: crypto.randomUUID(),
-      date: selectedDate
+      date: selectedDate,
     };
 
     setWorkouts([...workouts, newWorkout as Workout]);
@@ -115,7 +121,7 @@ const Workouts = () => {
 
   const handleEditWorkout = (updatedWorkout: Workout) => {
     setWorkouts(
-      workouts.map(workout => 
+      workouts.map((workout) =>
         workout.id === updatedWorkout.id ? updatedWorkout : workout
       )
     );
@@ -127,15 +133,17 @@ const Workouts = () => {
   };
 
   const handleDeleteWorkout = (workoutId: string) => {
-     //Delete from database
-     deleteWorkout(workoutId);
+    //Delete from database
+    deleteWorkout(workoutId);
 
-     //update the local storage
-    const workoutToDelete = workouts.find(w => w.id === workoutId);
-    setWorkouts(workouts.filter(workout => workout.id !== workoutId));
+    //update the local storage
+    const workoutToDelete = workouts.find((w) => w.id === workoutId);
+    setWorkouts(workouts.filter((workout) => workout.id !== workoutId));
     toast({
       title: "Workout Deleted",
-      description: workoutToDelete ? `${workoutToDelete.name} has been removed.` : "Workout has been removed.",
+      description: workoutToDelete
+        ? `${workoutToDelete.name} has been removed.`
+        : "Workout has been removed.",
       variant: "destructive",
     });
   };
@@ -144,12 +152,39 @@ const Workouts = () => {
     navigate(`/workouts/${workoutId}`);
   };
 
+  const handleCopyWorkout = (selectedWorkout: Workout) => {
+    const newWorkout = {
+      ...selectedWorkout,
+      id: crypto.randomUUID(), // Generate a new ID for the copied workout
+      date: new Date(),
+      userId: user?.uid,
+    };
+
+    const payload = {
+      workout: newWorkout,
+    };
+
+    // Save to database
+    saveWorkout(payload);
+
+    // Update local state
+    setWorkouts([...workouts, newWorkout]);
+
+    toast({
+      title: "Workout Copied",
+      description: `${selectedWorkout.name} has been copied to ${format(
+        selectedDate,
+        "MMMM d, yyyy"
+      )}.`,
+    });
+  };
+
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
       <main className="flex-1 container mx-auto px-4 py-8 mt-20">
         <h1 className="text-3xl font-bold mb-6">Workout Calendar</h1>
-        
+
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           <Card className="p-6 col-span-1 shadow-md flex flex-col items-center">
             <div className="w-full flex justify-center">
@@ -162,7 +197,8 @@ const Workouts = () => {
                   workout: workoutDates,
                 }}
                 modifiersClassNames={{
-                  workout: "bg-primary/10 text-primary font-medium border border-primary/20",
+                  workout:
+                    "bg-primary/10 text-primary font-medium border border-primary/20",
                 }}
               />
             </div>
@@ -171,20 +207,28 @@ const Workouts = () => {
           <Card className="p-4 col-span-1 md:col-span-2 shadow-md">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-xl font-medium">
-                {format(selectedDate, 'MMMM d, yyyy')}
+                {format(selectedDate, "MMMM d, yyyy")}
               </h2>
               {!isAddingWorkout && !editingWorkout && (
                 <div className="flex gap-2">
-                  <Button 
+                  <Button
                     variant="outline"
-                    onClick={() => setWorkoutDialogOpen(true)} 
+                    onClick={() => setWorkoutDialogOpen(true)}
                     className="flex items-center gap-1"
                   >
                     <FolderPlus className="h-4 w-4" />
                     Add Existing
                   </Button>
-                  <Button 
-                    onClick={handleCreateNewWorkout} 
+                  <Button
+                    variant="outline"
+                    onClick={() => setCopyWorkoutDialogOpen(true)} // New button
+                    className="flex items-center gap-1"
+                  >
+                    {/* Add the Copy icon from Lucide */}
+                    Copy Previous Workout
+                  </Button>
+                  <Button
+                    onClick={handleCreateNewWorkout}
                     className="flex items-center gap-1"
                   >
                     <PlusCircle className="h-4 w-4" />
@@ -201,21 +245,23 @@ const Workouts = () => {
                   {editingWorkout ? 'Edit Workout' : isAddingWorkout ? 'Add Workout' : 'Manage'}
                 </TabsTrigger> */}
               </TabsList>
-              
+
               <TabsContent value="workouts" className="space-y-4">
                 {selectedDateWorkouts.length > 0 ? (
-                  <WorkoutList 
-                    workouts={selectedDateWorkouts} 
+                  <WorkoutList
+                    workouts={selectedDateWorkouts}
                     onEdit={setEditingWorkout}
                     onDelete={handleDeleteWorkout}
                     onView={handleViewWorkoutDetails}
                   />
                 ) : (
                   <div className="text-center p-8 bg-secondary/20 rounded-lg">
-                    <p className="text-muted-foreground mb-4">No workouts scheduled for this day</p>
+                    <p className="text-muted-foreground mb-4">
+                      No workouts scheduled for this day
+                    </p>
                     {!isAddingWorkout && (
                       <div className="flex flex-col sm:flex-row justify-center gap-3">
-                        <Button 
+                        <Button
                           onClick={() => setWorkoutDialogOpen(true)}
                           variant="outline"
                           className="flex items-center gap-1"
@@ -223,7 +269,15 @@ const Workouts = () => {
                           <FolderPlus className="h-4 w-4" />
                           Add Existing Workout
                         </Button>
-                        <Button 
+                        <Button
+                          variant="outline"
+                          onClick={() => setCopyWorkoutDialogOpen(true)} // New button
+                          className="flex items-center gap-1"
+                        >
+                          {/* Add the Copy icon from Lucide */}
+                          Copy Previous Workout
+                        </Button>
+                        <Button
                           onClick={handleCreateNewWorkout}
                           className="flex items-center gap-1"
                         >
@@ -235,7 +289,7 @@ const Workouts = () => {
                   </div>
                 )}
               </TabsContent>
-              
+
               {/* <TabsContent value="manage">
                 {(isAddingWorkout || editingWorkout) && (
                   <WorkoutForm 
@@ -251,11 +305,17 @@ const Workouts = () => {
             </Tabs>
           </Card>
         </div>
-        
-        <WorkoutSelectionDialog 
+
+        <WorkoutSelectionDialog
           open={workoutDialogOpen}
           onOpenChange={setWorkoutDialogOpen}
           onSelectWorkout={handleSelectWorkout}
+        />
+        <CopyWorkoutDialog
+          open={copyWorkoutDialogOpen}
+          onOpenChange={setCopyWorkoutDialogOpen}
+          workouts={workouts}
+          onSelectWorkout={handleCopyWorkout}
         />
       </main>
       <Footer />


### PR DESCRIPTION
This PR introduces a new feature that allows users to copy a previous workout from their calendar and add it to the current day they are viewing.

- Added a "Copy Previous Workout" button to the calendar page.
- Implemented a workflow where users can:
- Click the button to open a modal.
- Select a previous date from the calendar to view its workout.
- Confirm and copy the selected workout to the current day.